### PR TITLE
Add key-value storage

### DIFF
--- a/app-data/src/main/java/me/dmba/mychecks/data/KeyValue.kt
+++ b/app-data/src/main/java/me/dmba/mychecks/data/KeyValue.kt
@@ -1,0 +1,20 @@
+package me.dmba.mychecks.data
+
+/**
+ * Created by dmba on 6/9/18.
+ */
+interface KeyValue {
+
+    fun put(key: String, value: Any)
+
+    fun getString(key: String, defaultValue: String = ""): String
+
+    fun getBool(key: String, defaultValue: Boolean = false): Boolean
+
+    fun getInt(key: String, defaultValue: Int = -1): Int
+
+    fun getLong(key: String, defaultValue: Long = -1): Long
+
+    fun getFloat(key: String, defaultValue: Float = -1F): Float
+
+}

--- a/app-data/src/main/java/me/dmba/mychecks/data/di/DataModule.kt
+++ b/app-data/src/main/java/me/dmba/mychecks/data/di/DataModule.kt
@@ -13,16 +13,24 @@ import me.dmba.mychecks.common.scopes.ForApplication
 import me.dmba.mychecks.data.ChecksDataContract
 import me.dmba.mychecks.data.ChecksDataContract.LocalDataSource
 import me.dmba.mychecks.data.ChecksDataContract.RemoteDataSource
+import me.dmba.mychecks.data.KeyValue
+import me.dmba.mychecks.data.keyvalue.SessionKeyValue
+import me.dmba.mychecks.data.keyvalue.SharedPrefsKeyValue
 import me.dmba.mychecks.data.source.ChecksRepo
 import me.dmba.mychecks.data.source.local.CHECKS_DB_NAME
 import me.dmba.mychecks.data.source.local.ChecksDao
 import me.dmba.mychecks.data.source.local.ChecksDatabase
 import me.dmba.mychecks.data.source.local.LocalChecksDataSource
 import me.dmba.mychecks.data.source.remote.RemoteChecksDataSource
+import javax.inject.Named
 
 /**
  * Created by dmba on 6/4/18.
  */
+
+const val KEY_VALUE_SESSION = "KV_SESSION"
+const val KEY_VALUE_PREFS = "KV_PREFS"
+
 @Module(
     includes = [
         DevDataModule::class,
@@ -59,6 +67,7 @@ object DataModule {
     internal fun provideGson(): Gson {
         return GsonBuilder().create()
     }
+
 }
 
 @Module
@@ -75,5 +84,15 @@ internal interface DataModuleBindings {
     @Binds
     @ForApplication
     fun bindsRepo(repo: ChecksRepo): ChecksDataContract.Repo
+
+    @Binds
+    @Named(KEY_VALUE_SESSION)
+    @ForApplication
+    fun bindsSessionKeyValue(storage: SessionKeyValue): KeyValue
+
+    @Binds
+    @Named(KEY_VALUE_PREFS)
+    @ForApplication
+    fun bindsPrefsKeyValue(storage: SharedPrefsKeyValue): KeyValue
 
 }

--- a/app-data/src/main/java/me/dmba/mychecks/data/keyvalue/SessionKeyValue.kt
+++ b/app-data/src/main/java/me/dmba/mychecks/data/keyvalue/SessionKeyValue.kt
@@ -1,0 +1,37 @@
+package me.dmba.mychecks.data.keyvalue
+
+import me.dmba.mychecks.data.KeyValue
+import javax.inject.Inject
+
+/**
+ * Created by dmba on 6/9/18.
+ */
+internal class SessionKeyValue @Inject constructor() : KeyValue {
+
+    private val map: MutableMap<String, Any> = mutableMapOf()
+
+    override fun put(key: String, value: Any) {
+        map[key] = value
+    }
+
+    override fun getString(key: String, defaultValue: String): String {
+        return map.getOrDefault(key, defaultValue) as String
+    }
+
+    override fun getBool(key: String, defaultValue: Boolean): Boolean {
+        return map.getOrDefault(key, defaultValue) as Boolean
+    }
+
+    override fun getInt(key: String, defaultValue: Int): Int {
+        return map.getOrDefault(key, defaultValue) as Int
+    }
+
+    override fun getLong(key: String, defaultValue: Long): Long {
+        return map.getOrDefault(key, defaultValue) as Long
+    }
+
+    override fun getFloat(key: String, defaultValue: Float): Float {
+        return map.getOrDefault(key, defaultValue) as Float
+    }
+
+}

--- a/app-data/src/main/java/me/dmba/mychecks/data/keyvalue/SharedPrefsKeyValue.kt
+++ b/app-data/src/main/java/me/dmba/mychecks/data/keyvalue/SharedPrefsKeyValue.kt
@@ -1,0 +1,48 @@
+package me.dmba.mychecks.data.keyvalue
+
+import android.content.SharedPreferences
+import me.dmba.mychecks.data.KeyValue
+import javax.inject.Inject
+
+/**
+ * Created by dmba on 6/9/18.
+ */
+internal class SharedPrefsKeyValue @Inject constructor(
+    private val prefs: SharedPreferences
+) : KeyValue {
+
+    override fun put(key: String, value: Any) {
+        val editor = prefs.edit()
+
+        when (value) {
+            is Boolean -> editor.putBoolean(key, value)
+            is String -> editor.putString(key, value)
+            is Float -> editor.putFloat(key, value)
+            is Long -> editor.putLong(key, value)
+            is Int -> editor.putInt(key, value)
+        }
+
+        editor.apply()
+    }
+
+    override fun getString(key: String, defaultValue: String): String {
+        return prefs.getString(key, defaultValue)
+    }
+
+    override fun getBool(key: String, defaultValue: Boolean): Boolean {
+        return prefs.getBoolean(key, defaultValue)
+    }
+
+    override fun getFloat(key: String, defaultValue: Float): Float {
+        return prefs.getFloat(key, defaultValue)
+    }
+
+    override fun getLong(key: String, defaultValue: Long): Long {
+        return prefs.getLong(key, defaultValue)
+    }
+
+    override fun getInt(key: String, defaultValue: Int): Int {
+        return prefs.getInt(key, defaultValue)
+    }
+
+}


### PR DESCRIPTION
Key value storage to store simple key-value pairs
for **Boolean**, **String**, **Int**, **Long**, **Float** types.

Contains 2 implementations:
- Shared Prefs key-value - uses app shared preferences to store data
- Session key-value - uses mutable map to store data, lives as long as application lives
